### PR TITLE
fix auth context token usage

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -40,16 +40,10 @@ const AuthProvider = ({ children }: IAuthProvider) => {
   const [user, setUser] = useState<IAuthUser | null>(null);
   const [profile, setProfile] = useState<IGoogleAuthUserInfo | null>(null);
   const [showSpiner, setShowSpiner] = useState<boolean>(false);
-  const USER_INFO_URL = `https://www.googleapis.com/oauth2/v1/userinfo?access_token=${user?.accessToken}`;
-
-  const headers = {
-    Authorization: `Bearer ${user?.accessToken}`,
-    Accept: 'application/json',
-  };
 
   const login = useGoogleLogin({
     onSuccess: ({ access_token }: TokenResponse) =>
-      setUser({ ...user, accessToken: access_token }),
+      setUser({ accessToken: access_token }),
     onError: () => console.log('error login'),
   });
 
@@ -59,6 +53,13 @@ const AuthProvider = ({ children }: IAuthProvider) => {
   };
 
   const getUserInfo = () => {
+    if (!user?.accessToken) return;
+    const USER_INFO_URL = `https://www.googleapis.com/oauth2/v1/userinfo?access_token=${user.accessToken}`;
+    const headers = {
+      Authorization: `Bearer ${user.accessToken}`,
+      Accept: 'application/json',
+    };
+
     setShowSpiner(true);
     axios
       .get(USER_INFO_URL, { headers })


### PR DESCRIPTION
## Summary
- avoid spreading null user on login
- compute user info request data dynamically from current token

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a45c4034d88326996c6472ee54a47b