### PR TITLE
Rename textToSpeach to textToSpeech

### DIFF
--- a/src/components/english/Items.tsx
+++ b/src/components/english/Items.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styles from '../../styles/Items.module.css'
 import { EnglishEntries } from '../../constants/english'
-import { textToSpeach } from '../../utils/textToSpeach'
+import { textToSpeech } from '../../utils/textToSpeech'
 import Separator from '../separator'
 
 interface IItems {
@@ -12,7 +12,7 @@ interface IItems {
 const Items = ({ items, selectedVoice }: IItems) => {
   return (
     <div className={styles.items}>
-      {<>{Object.keys(items).map(item => <div key={item} className={styles.item} onClick={() => textToSpeach(String(item), selectedVoice!)}>
+      {<>{Object.keys(items).map(item => <div key={item} className={styles.item} onClick={() => textToSpeech(String(item), selectedVoice!)}>
         {items[item]}
       </div>)}
       </>}

--- a/src/utils/textToSpeech.ts
+++ b/src/utils/textToSpeech.ts
@@ -1,4 +1,4 @@
-export const textToSpeach = async (item: string, voice:SpeechSynthesisVoice) => {
+export const textToSpeech = async (item: string, voice: SpeechSynthesisVoice) => {
   if ('speechSynthesis' in window) {
     const speech = new SpeechSynthesisUtterance(item)
     speech.voice = voice


### PR DESCRIPTION
## Summary
- rename `textToSpeach` utility and function to `textToSpeech`
- update Items component to use new `textToSpeech` helper
- remove remaining references to misspelled helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a45ebdc2dc8326b6b63b102dff2939