### PR TITLE
feat: add admin link and email configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 React Next TypeScript App for child educational process
+
+## Environment setup
+
+Create a `.env.local` file with the following variables to enable Google login
+and Firebase activity tracking:
+
+```
+GOOGLE_CLIENT_ID=your-google-client-id
+NEXT_PUBLIC_FIREBASE_API_KEY=your-firebase-api-key
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=your-firebase-auth-domain
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=your-firebase-project-id
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your-firebase-storage-bucket
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-firebase-messaging-sender-id
+NEXT_PUBLIC_FIREBASE_APP_ID=your-firebase-app-id
+ADMIN_ROUTE=your-admin-route
+ADMIN_PASSWORD=your-admin-password
+ADMIN_EMAIL=your-admin-email
+```
+
+`GOOGLE_CLIENT_ID` is consumed by `GoogleOAuthProvider` in
+`src/pages/_app.tsx`. The Firebase variables configure the Firestore database
+used to log user activity and progress. `ADMIN_ROUTE` rewrites to the admin
+page, `ADMIN_PASSWORD` protects access to the login logs, and `ADMIN_EMAIL`
+controls whether the logged-in user sees a link to the admin page.

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,10 @@
 
 const nextConfig = {
   env: {
-    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    ADMIN_ROUTE: process.env.ADMIN_ROUTE,
+    ADMIN_PASSWORD: process.env.ADMIN_PASSWORD,
+    ADMIN_EMAIL: process.env.ADMIN_EMAIL,
   },
   reactStrictMode: true,
   webpack: (config) => {
@@ -14,7 +17,18 @@ const nextConfig = {
     };
     config.resolve.alias['service-worker'] = './sw.js';
     return config;
-  }
-}
+  },
+  async rewrites() {
+    const adminRoute = process.env.ADMIN_ROUTE;
+    return adminRoute
+      ? [
+          {
+            source: `/${adminRoute}`,
+            destination: '/admin',
+          },
+        ]
+      : [];
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "axios": "^1.3.4",
     "dotenv": "^16.0.3",
     "lodash": "^4.17.21",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "firebase": "^9.22.2"
   }
 }

--- a/src/components/userMenu/index.tsx
+++ b/src/components/userMenu/index.tsx
@@ -1,5 +1,6 @@
 import { CircularProgress, Popover } from '@mui/material';
 import { useContext, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
 import { AuthContext } from '../../context/AuthContext';
 import styles from '../../styles/Nav.module.css'
 
@@ -7,6 +8,10 @@ const UserMenu = () => {
   const { login, logout, user, profile, showSpiner } = useContext(AuthContext);
   const [open, setOpen] = useState<boolean>(false);
   const anchorEl = useRef(null);
+  const router = useRouter();
+
+  const adminRoute = process.env.ADMIN_ROUTE;
+  const adminEmail = process.env.ADMIN_EMAIL;
 
   const handleOpen = () => {
     setOpen(true);
@@ -19,6 +24,13 @@ const UserMenu = () => {
   const handleLogout = () => {
     handleClose();
     logout();
+  };
+
+  const handleAdminClick = () => {
+    handleClose();
+    if (adminRoute) {
+      router.push(`/${adminRoute}`);
+    }
   };
 
   return (
@@ -55,6 +67,9 @@ const UserMenu = () => {
                   }}
                 >
                   <div className={styles['menu-wrapper']}>
+                    {profile?.email === adminEmail && (
+                      <button onClick={handleAdminClick}>Admin</button>
+                    )}
                     <button onClick={handleLogout}>Вийти</button>
                   </div>
                 </Popover>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { ROOT_PATH } from '../constants';
 import { IAuthUser, IGoogleAuthUserInfo } from '../types';
+import { logLogin } from '../utils/activity';
 
 type AuthValuesType = {
   user: IAuthUser | null;
@@ -49,7 +50,7 @@ const AuthProvider = ({ children }: IAuthProvider) => {
 
   const login = useGoogleLogin({
     onSuccess: ({ access_token }: TokenResponse) =>
-      setUser({ ...user, accessToken: access_token }),
+      setUser({ accessToken: access_token }),
     onError: () => console.log('error login'),
   });
 
@@ -62,7 +63,10 @@ const AuthProvider = ({ children }: IAuthProvider) => {
     setShowSpiner(true);
     axios
       .get(USER_INFO_URL, { headers })
-      .then(({ data }: any) => setProfile(data))
+      .then(({ data }: any) => {
+        setProfile(data);
+        logLogin(data);
+      })
       .catch((err) => console.log(err))
       .finally(() => setShowSpiner(false));
   };

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState, FormEvent } from 'react';
+import { fetchLoginLogs } from '../../utils/activity';
+
+interface LoginLog {
+  userId: string;
+  email: string;
+  name: string;
+  timestamp: string;
+}
+
+const AdminPage = () => {
+  const [password, setPassword] = useState('');
+  const [authorized, setAuthorized] = useState(false);
+  const [logs, setLogs] = useState<LoginLog[]>([]);
+
+  const submitHandler = (e: FormEvent) => {
+    e.preventDefault();
+    if (password === process.env.ADMIN_PASSWORD) {
+      setAuthorized(true);
+    }
+  };
+
+  useEffect(() => {
+    if (authorized) {
+      fetchLoginLogs().then(setLogs).catch(console.error);
+    }
+  }, [authorized]);
+
+  if (!authorized) {
+    return (
+      <form onSubmit={submitHandler}>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Admin password"
+        />
+        <button type="submit">Enter</button>
+      </form>
+    );
+  }
+
+  return (
+    <div>
+      <h1>Login Logs</h1>
+      <ul>
+        {logs.map((log) => (
+          <li key={log.timestamp}>
+            {log.email} - {new Date(log.timestamp).toLocaleString()}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AdminPage;
+

--- a/src/types/firebase.d.ts
+++ b/src/types/firebase.d.ts
@@ -1,0 +1,3 @@
+declare module 'firebase/app';
+declare module 'firebase/firestore';
+

--- a/src/utils/activity.ts
+++ b/src/utils/activity.ts
@@ -1,0 +1,60 @@
+/* eslint-disable import/no-unresolved */
+import { collection, addDoc, getDocs, orderBy, query } from 'firebase/firestore';
+/* eslint-enable import/no-unresolved */
+
+import { db } from './firebase';
+
+export const logUserActivity = async (
+  userId: string,
+  activity: string
+): Promise<void> => {
+  try {
+    await addDoc(collection(db, 'users', userId, 'activities'), {
+      activity,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('Error logging activity', error);
+  }
+};
+
+export const logUserProgress = async (
+  userId: string,
+  progress: Record<string, unknown>
+): Promise<void> => {
+  try {
+    await addDoc(collection(db, 'users', userId, 'progress'), {
+      ...progress,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('Error logging progress', error);
+  }
+};
+
+export const logLogin = async (
+  user: { id: string; email: string; name: string }
+): Promise<void> => {
+  try {
+    await addDoc(collection(db, 'loginLogs'), {
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('Error logging login', error);
+  }
+};
+
+export const fetchLoginLogs = async (): Promise<
+  { userId: string; email: string; name: string; timestamp: string }[]
+> => {
+  const q = query(
+    collection(db, 'loginLogs'),
+    orderBy('timestamp', 'desc')
+  );
+  const snapshot = await getDocs(q);
+  return snapshot.docs.map((doc) => doc.data() as any);
+};
+

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -1,0 +1,18 @@
+/* eslint-disable import/no-unresolved */
+import { initializeApp, getApp, getApps } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+/* eslint-enable import/no-unresolved */
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+
+export const db = getFirestore(app);
+


### PR DESCRIPTION
## Summary
- expose ADMIN_EMAIL and dynamically configure admin route rewrites
- show admin page link in user menu only for configured admin email
- document new ADMIN_EMAIL environment variable

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a45c404ad08326b6f94a361387cdc8