### PR TITLE
Log Google logins and restrict admin logs

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -53,7 +53,7 @@ const AuthProvider = ({ children }: IAuthProvider) => {
     setUser(null);
   };
 
-  const getUserInfo = () => {
+  const getUserInfo = async () => {
     if (!user?.accessToken) return;
     const USER_INFO_URL = `https://www.googleapis.com/oauth2/v1/userinfo?access_token=${user.accessToken}`;
     const headers = {
@@ -62,14 +62,15 @@ const AuthProvider = ({ children }: IAuthProvider) => {
     };
 
     setShowSpiner(true);
-    axios
-      .get(USER_INFO_URL, { headers })
-      .then(({ data }: any) => {
-        setProfile(data);
-        logLogin(data);
-      })
-      .catch((err) => console.log(err))
-      .finally(() => setShowSpiner(false));
+    try {
+      const { data }: any = await axios.get(USER_INFO_URL, { headers });
+      setProfile(data);
+      await logLogin(data);
+    } catch (err) {
+      console.log(err);
+    } finally {
+      setShowSpiner(false);
+    }
   };
 
   const values = {

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, FormEvent } from 'react';
+import { useEffect, useState, FormEvent, useContext } from 'react';
 import { fetchLoginLogs } from '../../utils/activity';
+import { AuthContext } from '../../context/AuthContext';
 
 interface LoginLog {
   userId: string;
@@ -9,13 +10,18 @@ interface LoginLog {
 }
 
 const AdminPage = () => {
+  const { profile } = useContext(AuthContext);
+  const adminEmail = process.env.ADMIN_EMAIL;
   const [password, setPassword] = useState('');
   const [authorized, setAuthorized] = useState(false);
   const [logs, setLogs] = useState<LoginLog[]>([]);
 
   const submitHandler = (e: FormEvent) => {
     e.preventDefault();
-    if (password === process.env.ADMIN_PASSWORD) {
+    if (
+      password === process.env.ADMIN_PASSWORD &&
+      profile?.email === adminEmail
+    ) {
       setAuthorized(true);
     }
   };
@@ -25,6 +31,10 @@ const AdminPage = () => {
       fetchLoginLogs().then(setLogs).catch(console.error);
     }
   }, [authorized]);
+
+  if (profile?.email !== adminEmail) {
+    return <p>Unauthorized</p>;
+  }
 
   if (!authorized) {
     return (


### PR DESCRIPTION
## Summary
- ensure login events persist email and timestamp on each Google sign-in
- restrict login log viewing to authenticated admin users

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a4a655fb40832684e529ed6c8cc678