### PR TITLE
Fix spinner stuck after Google login

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -65,7 +65,9 @@ const AuthProvider = ({ children }: IAuthProvider) => {
     try {
       const { data }: any = await axios.get(USER_INFO_URL, { headers });
       setProfile(data);
-      await logLogin({ id: data.id, email: data.email, name: data.name });
+      logLogin({ id: data.id, email: data.email, name: data.name }).catch(
+        (error) => console.error('Error logging login', error)
+      );
     } catch (err) {
       console.log(err);
     } finally {


### PR DESCRIPTION
## Summary
- prevent login spinner from blocking UI if login logging fails

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a4d250edd08326b94b859d73bd3b19