### PR TITLE
Log Google sign-ins and list in admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ ADMIN_EMAIL=your-admin-email
 
 `GOOGLE_CLIENT_ID` is consumed by `GoogleOAuthProvider` in
 `src/pages/_app.tsx`. The Firebase variables configure the Firestore database
-used to log user activity and progress. `ADMIN_ROUTE` rewrites to the admin
-page, `ADMIN_PASSWORD` protects access to the login logs, and `ADMIN_EMAIL`
-controls whether the logged-in user sees a link to the admin page.
+used to log user activity, progress, and each Google sign-in. Login events are
+stored in the `logins` collection with the user's email and a timestamp and are
+listed on the admin page. `ADMIN_ROUTE` rewrites to the admin page,
+`ADMIN_PASSWORD` protects access to the login logs, and `ADMIN_EMAIL` controls
+whether the logged-in user sees a link to the admin page.

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -2,10 +2,9 @@ import { useEffect, useState, FormEvent, useContext } from 'react';
 import { fetchLoginLogs } from '../../utils/activity';
 import { AuthContext } from '../../context/AuthContext';
 
-interface UserLogs {
+interface LogEntry {
   email: string;
-  name: string;
-  logs: { timestamp: string }[];
+  timestamp: string;
 }
 
 const AdminPage = () => {
@@ -13,7 +12,7 @@ const AdminPage = () => {
   const adminEmail = process.env.ADMIN_EMAIL;
   const [password, setPassword] = useState('');
   const [authorized, setAuthorized] = useState(false);
-  const [logs, setLogs] = useState<UserLogs[]>([]);
+  const [logs, setLogs] = useState<LogEntry[]>([]);
   const [pageSize, setPageSize] = useState(10);
   const [page, setPage] = useState(0);
 
@@ -72,16 +71,9 @@ const AdminPage = () => {
         </select>
       </label>
       <ul>
-        {paginated.map((user) => (
-          <li key={user.email}>
-            <strong>{user.email}</strong>
-            <ul>
-              {user.logs.map((log) => (
-                <li key={log.timestamp}>
-                  {new Date(log.timestamp).toLocaleString()}
-                </li>
-              ))}
-            </ul>
+        {paginated.map((log) => (
+          <li key={`${log.email}-${log.timestamp}`}>
+            {log.email} - {new Date(log.timestamp).toLocaleString()}
           </li>
         ))}
       </ul>

--- a/src/utils/activity.ts
+++ b/src/utils/activity.ts
@@ -5,8 +5,6 @@ import {
   getDocs,
   orderBy,
   query,
-  doc,
-  setDoc,
 } from 'firebase/firestore';
 /* eslint-enable import/no-unresolved */
 
@@ -44,10 +42,8 @@ export const logLogin = async (
   user: { id: string; email: string; name: string }
 ): Promise<void> => {
   try {
-    const userRef = doc(db, 'loginLogs', user.email);
-    await setDoc(userRef, { email: user.email, name: user.name }, { merge: true });
-    await addDoc(collection(userRef, 'logs'), {
-      userId: user.id,
+    await addDoc(collection(db, 'logins'), {
+      email: user.email,
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
@@ -56,21 +52,11 @@ export const logLogin = async (
 };
 
 export const fetchLoginLogs = async (): Promise<
-  { email: string; name: string; logs: { timestamp: string }[] }[]
+  { email: string; timestamp: string }[]
 > => {
-  const usersSnapshot = await getDocs(collection(db, 'loginLogs'));
-  const userLogs = await Promise.all(
-    usersSnapshot.docs.map(async (userDoc) => {
-      const logsSnapshot = await getDocs(
-        query(collection(userDoc.ref, 'logs'), orderBy('timestamp', 'desc'))
-      );
-      return {
-        email: userDoc.id,
-        ...(userDoc.data() as any),
-        logs: logsSnapshot.docs.map((d) => d.data() as any),
-      };
-    })
+  const logsSnapshot = await getDocs(
+    query(collection(db, 'logins'), orderBy('timestamp', 'desc'))
   );
-  return userLogs.sort((a, b) => a.email.localeCompare(b.email));
+  return logsSnapshot.docs.map((d) => d.data() as { email: string; timestamp: string });
 };
 


### PR DESCRIPTION
## Summary
- log each Google login to Firestore `logins` collection
- show login list with email and timestamp on admin page
- document login log behaviour in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e78b197883268433904e8c23957c